### PR TITLE
node: upgrade nodejs version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: '23'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Previously added 23rd version was restored to 16.
Upgrading to nodeJs version 23 due to unmatched dependencies with @cucumber/cucumber