### PR TITLE
chrome:Enable headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ launch.json (VSCode Debug Configuration)
 ```
 This configuration allows you to debug the Cucumber tests directly from VSCode.
 
+```
+Node: The project is configured in headless mode, if you would like to launch a browser you should remove
+.setChromeOptions(chromeOptions)
+from BeforeAll
+```
+
 ## Troubleshooting
 Missing .env file: If the .env file is missing, make sure to create it as per the instructions above.
 API Key Errors: Double-check that the API key is correctly set in the .env file.

--- a/features/step_definitions/btc_steps.js
+++ b/features/step_definitions/btc_steps.js
@@ -1,6 +1,7 @@
 const { Given, When, Then, Before, BeforeAll, AfterAll } = require('@cucumber/cucumber');
 const { setDefaultTimeout } = require('@cucumber/cucumber');
 const { Builder } = require('selenium-webdriver');
+const chrome = require('selenium-webdriver/chrome');
 const utils = require('../../utils');
 const FinancePage = require('../pages/finance.btc.page');
 const Helpers = require('../../helpers');
@@ -21,15 +22,24 @@ const Number = 'number';
 let driver;
 let financePage;
 let helpers;
+let chromeOptions;
 let apiPrice;
 let uiPrice;
 let initialPrice;
 let recordedPrices = [];
 
+chromeOptions = new chrome.Options();
+chromeOptions.addArguments(
+  'headless',
+  'no-sandbox',
+  'disable-dev-shm-usage',
+  'remote-debugging-port=9222'
+);
+
 BeforeAll(async () => {
     // Initialize driver only if it's not already initialized
     if (!driver) {
-        driver = await new Builder().forBrowser(Chrome).build();
+        driver = await new Builder().forBrowser(Chrome).setChromeOptions(chromeOptions).build();
         financePage = new FinancePage(driver);
         helpers = new Helpers(driver);
     }
@@ -89,7 +99,7 @@ Then(
         }
 
         console.log(`Recorded prices: ${recordedPrices}`);
-        
+
         // Calculate average price
         const sumPrices = recordedPrices.reduce((sum, price) => sum + price, 0);
         const averagePrice = sumPrices / recordedPrices.length;


### PR DESCRIPTION
Enable chrome headless mode to speed up the test execution and reduce the usage of resources.